### PR TITLE
update numerical order, add colon

### DIFF
--- a/docs-dingo-postgresql/object-store.html.md.erb
+++ b/docs-dingo-postgresql/object-store.html.md.erb
@@ -4,9 +4,9 @@ title: Secure Object Store
 
 ## Setup a Secure Object Store with Amazon S3
 
-1. In the AWS web console, use the black bar at the top to navigate to Services
-\> **IAM**. The Dashboard on the left has a **Users** section.  Choose **Users**
-and a list of existing users for your account appears.
+1. In the AWS web console, use the black bar at the top to navigate to Services **IAM**.
+The Dashboard on the left has a **Users** section.  Choose **Users** and a list
+of existing users for your account appears.
 
 2. Let's add a new user to your AWS account.  Click on the big blue button
 labeled **Create New Users**.  Give the user a name like `dingo-postgresql` and
@@ -21,14 +21,13 @@ click **Create** in the bottom right.
 3. Now let's create the S3 bucket.  Navigate to Services > **S3**, then choose
 the blue **Create Bucket** button.
 
-  > Amazon S3 bucket names are globally unique, regardless of the AWS Region in
-  which you create the bucket [1][Using Buckets].
+  Amazon S3 bucket names are globally unique, regardless of the AWS Region in
+  which you [create the bucket](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html).
 
-4. The S3 bucket name needs to be unique and should comply with DNS naming
-conventions[2][Bucket Restrictions].  The best region is one closest to your
-datacenter.
+4. The S3 bucket name needs to be unique and should comply with [DNS naming conventions](http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html).
+The best region is one closest to your datacenter.
 
-  Once a bucket is created the [website endpoint][Website Endpoints]
+  Once a bucket is created the [website endpoint](http://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html)
   looks like this:
 
   ```
@@ -36,13 +35,13 @@ datacenter.
   ```
 
   Replace the `bucket-name` and `region` to get your URL.  Check the
-  [website endpoint][Website Endpoints] page for a reference of the region URL
-  portion.
+  [website endpoint](http://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html)
+  page for a reference of the region URL portion.
 
-5. Next we will create a custom IAM policy for the S3 user.  Browse to Services
-\> **IAM**, then in the Dashboard select **Users**.  Find the `dingo-postgresql`
-user and select that user.  Take note of the _User ARN_ value, we're going to
-use it in the policy we create.  It will look something like this:
+5. Next we will create a custom IAM policy for the S3 user.  Browse to Services **IAM**,
+then in the Dashboard select **Users**.  Find the `dingo-postgresql` user and
+select that user.  Take note of the _User ARN_ value, we're going to use it in
+the policy we create.  It will look something like this:
 
   ```
   arn:aws:iam::693782881333:user/dingo-postgresql
@@ -67,7 +66,7 @@ your values.
       {
         "Effect"   : "Allow",
         "Action"   : "s3:ListAllMyBuckets",
-        "Resource" : "arn:aws:iam:xxxxxxxxxxxx:user/zzzzz"
+        "Resource" : "arn:aws:iam::xxxxxxxxxxxx:user/zzzzz"
       },
       {
         "Effect"   : "Allow",
@@ -80,9 +79,3 @@ your values.
     ]
   }
   ```
-
-[//]: # (Links, please keep in alphabetical order)
-
-[Bucket Restrictions]: http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
-[Using Buckets]:       http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html
-[Website Endpoints]:   http://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html


### PR DESCRIPTION
Currently the ordinal numbers are resetting on each paragraph.  Working to try and get the numbers to continue throughout the document.  The formatting works in other markdown readers.

For instance: https://gist.github.com/7hunderbird/f5cd5c2416bd8ff9b448d136ec589848

Also added missing `:` to example Policy.
