### PR TITLE
add support policy doc

### DIFF
--- a/docs-book/master_middleman/source/subnavs/_dingo_postgresql_subnav.erb
+++ b/docs-book/master_middleman/source/subnavs/_dingo_postgresql_subnav.erb
@@ -22,6 +22,9 @@
             <li class="menu-link">
               <a href="/dingo-postgresql/eula.html">EULA</a>
             </li>
+            <li class="menu-link">
+              <a href="/dingo-postgresql/eol-support-policy.html">EOL Support Policy</a>
+            </li>
           </ul>
         </div>
       </li>

--- a/docs-dingo-postgresql/eol-support-policy.html.md.erb
+++ b/docs-dingo-postgresql/eol-support-policy.html.md.erb
@@ -1,0 +1,25 @@
+# Dingo PostgreSQL End of Life Support Policy
+
+This policy is applicable only to the Dingo PostgreSQL for Pivotal Cloud Foundry tile distributed and sold through Pivotal Network.
+
+## Definitions
+
+**General Tile Support** - Maintenance updates and upgrades, bug and security fixes, and technical assistance for the Dingo PostgreSQL tile operating on Pivotal Cloud Foundry. These include security vulnerability resolutions and critical bug fixes in all supported Minor versions, while other maintenance is applied only to the latest supported Minor Release. Additional scope, including timeline, of this support phase will be detailed in the customer contract.
+
+**Advanced PostgreSQL Support** - Consulting and support regarding PostgreSQL operation in the customer’s infrastructure. The details, SLA’s, and timetables regarding this support phase are designed and executed based on customer contract. A 3rd party vendor may fully or partially provide this support.
+
+**Technical Guidance** - Limited support available after General Tile Support ends. Customers may continue to access Pivotal and Stark & Wayne’s online tools for self-service. However, telephone and other forms of person-to-person support are no longer provided. Customers can open a support request online to receive support and workarounds for non-business critical issues on supported configurations only. Stark & Wayne will not provide server/client/guest OS updates, new security patches, or bug fixes under Technical Guidance unless otherwise noted. This phase is intended for customers operating in stable environments with systems operating under reasonably stable loads.
+
+**General Availability** - Product tile is available for purchase and download by customers.
+
+**End of Availability** - Product tile is no longer available for purchase from Pivotal and, as such, no longer appears on Pivotal’s price list.
+
+**End of Tile Support** - Stark & Wayne no longer provides General Tile Support. Advanced PostgreSQL Support may continue based on customer contract. Technical Guidance is offered with no guarantees on response times and resolutions.
+
+## Timetable
+
+General Tile Support is offered for a minimum of 1 year following the General Availability release of each tile Major version release and ends as stipulated in the customer contract.
+
+End of Availability for each Major release of the tile will be announced 6 months before its date. At the start of End of Availability, General Tile Support will continue for that Major release for 6 months until End of Tile Support or as otherwise stipulated in the customer contract. Technical Guidance will be offered at the discretion of Stark & Wayne.
+
+Advanced PostgreSQL Support will begin and end based on the stipulations of the customer contract.


### PR DESCRIPTION
In order to help customers understand the Support Policy terms when they get Dingo PostgreSQL for Pivotal Cloud Foundry tile distributed and sold through Pivotal Network, this document defines terms and sets timetables.
